### PR TITLE
khronos-opencl-icd-loader 2025.07.22

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/opencl-headers-feedstock/pr1/a481996

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/opencl-headers-feedstock/pr1/a481996

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -22,10 +22,6 @@ REM Install step
 cmake --build . --config "%BUILD_CONFIG%" --target install
 if errorlevel 1 exit 1
 
-mkdir %LIBRARY_INC%\CL
-XCOPY %SRC_DIR%\inc\CL\* %LIBRARY_INC%\CL /s /i /y
-if errorlevel 1 exit 1
-
 :: Copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.
 :: This will allow them to be run on environment activation.
 for %%F in (activate deactivate) DO (

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,10 +6,3 @@ cd build
 cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_BUILD_TYPE=Release ..
 make -j${CPU_COUNT}
 make install
-
-mkdir -p $PREFIX/include/CL
-cp $SRC_DIR/inc/CL/* $PREFIX/include/CL/
-
-if [[ "${target_platform}" == osx* ]]; then
-    ln -s $PREFIX/include/CL $PREFIX/include/OpenCL
-fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,13 @@ about:
   license: Apache-2.0
   license_file: LICENSE
   summary: A driver loader for OpenCL
+  description: |
+    An ICD loader for OpenCL. OpenCL defines an Installable Client 
+    Driver (ICD) mechanism to allow developers to build applications
+    against an Installable Client Driver loader (ICD loader) rather
+    than linking their applications against a specific OpenCL 
+    implementation. This package contains the loader, not any
+    specific driverss.
   dev_url: https://github.com/KhronosGroup/OpenCL-ICD-Loader
   doc_url: https://registry.khronos.org/OpenCL/
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,8 @@ requirements:
     - cmake
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
-    - python
     - make   # [not win]
-    - ninja  # [win]
+    - ninja-base  # [win]
   host:
     - opencl-headers ={{ version }}
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2024.05.08" %}
+{% set version = "2025.07.22" %}
 
 package:
   name: khronos-opencl-icd-loader
@@ -6,13 +6,9 @@ package:
 
 source:
   - url: https://github.com/KhronosGroup/OpenCL-ICD-Loader/archive/refs/tags/v{{ version }}.zip
-    sha256: 3326b81cd47829a8b738465944674e94332b55d988e12bbb760f54d71a0ac9a6
+    sha256: db29e0028ff1ee5f166ce726ad046375233bb530ea98c00e05f4b1e517343771
     patches:
       - no_check_integrity_win.patch
-
-  - url: https://github.com/KhronosGroup/OpenCL-Headers/archive/v{{ version }}.zip
-    sha256: 83296f08e670d8f52c94972587f22ad8cbbb1383aa00b11f376a9c01686bf399
-    folder: inc
 
 build:
   number: 0
@@ -28,19 +24,27 @@ requirements:
   build:
     - cmake
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - python
     - make   # [not win]
     - ninja  # [win]
   host:
+    - opencl-headers ={{ version }}
   run:
+    - {{ pin_compatible("opencl-headers", max_pin=None) }}
+
 
 test:
+  requires:
+    - pkg-config
   commands:
     - if not exist %LIBRARY_INC%\\CL\\cl.h exit 1       # [win]
     - if not exist %LIBRARY_BIN%\\OpenCL.dll exit 1     # [win]
     - test -f $PREFIX/include/OpenCL/cl.h               # [osx]
     - test -f $PREFIX/include/CL/cl.h                   # [linux]
     - test -f $PREFIX/lib/libOpenCL${SHLIB_EXT}         # [unix]
+    - cllayerinfo
+    - pkg-config OpenCL --libs --cflags
 
     # This crashes with a segfault. Likely for a lack of ICD to talk to.
     # - cd %SRC_DIR%/build && ctest
@@ -49,12 +53,12 @@ test:
   #   - pyopencl
 
 about:
-  home: https://www.khronos.org/registry/cl/
-  dev_url: https://github.com/KhronosGroup/OpenCL-ICD-Loader
+  home: https://registry.khronos.org/OpenCL/
   license: Apache-2.0
   license_file: LICENSE
   summary: A driver loader for OpenCL
-
+  dev_url: https://github.com/KhronosGroup/OpenCL-ICD-Loader
+  doc_url: https://registry.khronos.org/OpenCL/
 extra:
   recipe-maintainers:
     - inducer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,6 @@ test:
     - test -f $PREFIX/include/OpenCL/cl.h               # [osx]
     - test -f $PREFIX/include/CL/cl.h                   # [linux]
     - test -f $PREFIX/lib/libOpenCL${SHLIB_EXT}         # [unix]
-    - cllayerinfo
     - pkg-config OpenCL --libs --cflags
 
     # This crashes with a segfault. Likely for a lack of ICD to talk to.


### PR DESCRIPTION
khronos-opencl-icd-loader 2025.07.22

**Destination channel:** defaults

### Links

- [PKG-10625](https://anaconda.atlassian.net/browse/PKG-10625)
- conda-forge: https://github.com/conda-forge/khronos-opencl-icd-loader-feedstock
- Upstream repository: https://github.com/KhronosGroup/OpenCL-ICD-Loader
- Upstream changelog: https://github.com/KhronosGroup/OpenCL-ICD-Loader/releases

### Explanation of changes:
 - Adapting to 2025.07.22. 
 - Unvendoring the headers, which will now be included in the opencl-headers package. 


[PKG-10625]: https://anaconda.atlassian.net/browse/PKG-10625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ